### PR TITLE
Update default transcoding options (centers videos)

### DIFF
--- a/src/com/entertailion/java/fling/FlingFrame.java
+++ b/src/com/entertailion/java/fling/FlingFrame.java
@@ -79,7 +79,7 @@ public class FlingFrame extends JFrame implements ActionListener, BroadcastDisco
 	private static final String HEADER_APPLICATION_URL = "Application-URL";
 	private static final String CHROME_CAST_MODEL_NAME = "Eureka Dongle";
 	private static final String TRANSCODING_EXTENSIONS = "wmv,avi,mkv,mpg,mpeg,flv,3gp,ogm";
-	private static final String TRANSCODING_PARAMETERS = "vcodec=VP80,vb=1000,width=500,acodec=vorb,ab=128,channels=2,samplerate=44100";
+	private static final String TRANSCODING_PARAMETERS = "vcodec=VP80,vb=1000,vfilter=canvas{width=640,height=360},acodec=vorb,ab=128,channels=2,samplerate=44100";
 	private static final String PROPERTY_TRANSCODING_EXTENSIONS = "transcoding.extensions";
 	private static final String PROPERTY_TRANSCODING_PARAMETERS = "transcoding.parameters";
 	private static final String SELECTED_NETWORK = "selected.network";


### PR DESCRIPTION
The current transcoding options combined with the CSS cause videos to be top aligned.
This change adds black bars to the video to center it.

The resolution could be changed according to user preference / computer power / available bandwidth, but I put a safe one in there for now.
