### PR TITLE
Added code to have Fling try to match the System Look and Feel.

### DIFF
--- a/src/com/entertailion/java/fling/Fling.java
+++ b/src/com/entertailion/java/fling/Fling.java
@@ -17,6 +17,7 @@ import java.awt.Toolkit;
 import java.net.URL;
 
 import javax.swing.WindowConstants;
+import javax.swing.UIManager;
 
 //import uk.co.caprica.vlcj.binding.LibVlc;
 import uk.co.caprica.vlcj.runtime.RuntimeUtil;
@@ -79,6 +80,12 @@ public class Fling {
 	 * Create the main window frame
 	 */
 	public static void createAndShowGUI() {
+		Log.d(LOG_TAG, "set to system default LaF");
+		try {
+			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+		} catch(Exception ex) {
+			System.out.println("Cannot find system look and feel, setting to metal.");
+		}
 		Log.d(LOG_TAG, "createAndShowGUI");
 		flingFrame = new FlingFrame();
 		// change the default app icon; might not work for all platforms


### PR DESCRIPTION
On non-Mac platforms, unless the user has a system-wide default LookAndFeel set, Fling uses the Java default (Metal) which is very old looking.

The added code sets the UI to the LAF matching the System OS, one mirroring GTK for Gnome, one resembling Windows, and leaves it the same for Apple.

Below shows the default on non-Apple platforms and a localized version after adding the code to select the LAF.

![Before - with Metal LAF](https://f.cloud.github.com/assets/66931/1011651/f13be0ce-0b60-11e3-9413-20e8627725b4.png)
![After - on a Linux machine running Gnome](https://f.cloud.github.com/assets/66931/1011656/f6cdc688-0b60-11e3-94a7-407e09ff760f.png)
